### PR TITLE
Internationalize tabs

### DIFF
--- a/src/Translatable.php
+++ b/src/Translatable.php
@@ -25,7 +25,11 @@ class Translatable extends Field
     {
         parent::__construct($name, $attribute, $resolveCallback);
 
-        $this->withMeta(['locales' => config('translatable.locales')]);
+        foreach ($locales = config('translatable.locales') as $key => $value) {
+            $locales[$key] = __($value);
+        }
+
+        $this->withMeta(compact('locales'));
         $this->withMeta(['indexLocale' => app()->getLocale()]);
     }
 


### PR DESCRIPTION
Hello,

I'm proposing a very little change to make sure that tabs are displayed in the correct language. See below what I mean.

`config/translatable.php`:
```php
<?php

return [
    'locales' => [
        'en' => 'English',
        'fr' => 'French',
    ],
];
```

`resources/lang/fr.json`:
```json
{
    "English": "Anglais",
    "French": "Français",
}
```

My tabs when my locale is `fr`:

![capture d ecran de 2018-08-29 11-21-56](https://user-images.githubusercontent.com/3613731/44778702-f6856880-ab7d-11e8-9e83-e45560d5e8de.png)
