### PR TITLE
WiP — Make field compatible with both dimsav/laravel-translatable and spatie/laravel-translatable

### DIFF
--- a/src/Translatable.php
+++ b/src/Translatable.php
@@ -2,6 +2,7 @@
 
 namespace MrMonat\Translatable;
 
+use Laravel\Nova\Http\Requests\NovaRequest;
 use Laravel\Nova\Fields\Field;
 
 class Translatable extends Field
@@ -44,10 +45,37 @@ class Translatable extends Field
      */
     protected function resolveAttribute($resource, $attribute)
     {
-        if (method_exists($resource, 'getTranslations')) {
-            return $resource->getTranslations($attribute);
+        $results = [];
+        if ( class_exists('\Spatie\Translatable\TranslatableServiceProvider') && method_exists($resource, 'getTranslations') ) {
+            $results = $resource->getTranslations($attribute);
+        } elseif ( class_exists('\Dimsav\Translatable\TranslatableServiceProvider') && method_exists($resource, 'translations') ) {
+            $results =  $resource->translations->pluck($attribute, config('translatable.locale_key'));
+        } else {
+            $results = data_get($resource, $attribute);
         }
-        return data_get($resource, $attribute);
+        return $results;
+    }
+
+    /**
+     * Hydrate the given attribute on the model based on the incoming request.
+     *
+     * @param  \Laravel\Nova\Http\Requests\NovaRequest  $request
+     * @param  string  $requestAttribute
+     * @param  object  $model
+     * @param  string  $attribute
+     * @return void
+     */
+    protected function fillAttributeFromRequest(NovaRequest $request, $requestAttribute, $model, $attribute)
+    {
+        if ( class_exists('\Dimsav\Translatable\TranslatableServiceProvider') && method_exists($model, 'translateOrNew') ) {
+            if ( is_array($request[$requestAttribute]) ) {
+                foreach ( $request[$requestAttribute] as $lang => $value ) {
+                    $model->translateOrNew($lang)->{$attribute} = $value;
+                }
+            }
+        } else {
+            parent::fillAttributeFromRequest($request, $requestAttribute, $model, $attribute);
+        }
     }
 
     /**


### PR DESCRIPTION
Hello World!

For some of our needs, we tweaked nova-translatable to make it work with [dimsav/laravel-translatable](https://github.com/dimsav/laravel-translatable) instead of [spatie/laravel-translatable](https://github.com/spatie/laravel-translatable). Then we took some time to improve our fork so it works with both packages.

The changes are kept as minimal as possible to allow nova-translatable to be used in the exact same way no matter the underlying laravel-translatable package available.

It isn’t ready for merging yet, as we still need to find a way to improve the composer dependencies check so nova-translatable can be installed as long as one of the supported laravel-translatable packages is available.

All suggestions to work around the lack of a logical OR in composer dependencies handling would be most welcome ;)