### PR TITLE
Update spatie/laravel-translatable to 3.0

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -9,7 +9,7 @@
     "license": "MIT",
     "require": {
         "php": ">=7.1.0",
-        "spatie/laravel-translatable": "^2.2"
+        "spatie/laravel-translatable": "^3.0"
     },
     "autoload": {
         "psr-4": {


### PR DESCRIPTION
Unable to install when using 2.2. Locally everything still seems fine at 3.0.

From laravel-translatable readme:

**Upgrade from v2 to v3**
In most cases you can upgrade without making any changes to your codebase at all. v3 introduced a translations accessor on your models. If you already had one defined on your model, you'll need to rename it.