### PR TITLE
🚀 add the ability to sort by translatable field

### DIFF
--- a/src/Translatable.php
+++ b/src/Translatable.php
@@ -14,6 +14,13 @@ class Translatable extends Field
     public $component = 'translatable';
 
     /**
+     * The index's locale.
+     *
+     * @var string
+     */
+    protected $indexLocale;
+
+    /**
      * Create a new field.
      *
      * @param  string  $name
@@ -68,6 +75,8 @@ class Translatable extends Field
      */
     public function indexLocale($locale)
     {
+        $this->indexLocale = $locale;
+
         return $this->withMeta(['indexLocale' => $locale]);
     }
 
@@ -112,5 +121,15 @@ class Translatable extends Field
     public function truncate()
     {
         return $this->withMeta(['truncate' => true]);
+    }
+
+    /**
+     * Return the sortable uri key for the field.
+     *
+     * @return string
+     */
+    public function sortableUriKey()
+    {
+        return implode('->', array_filter([$this->attribute, $this->indexLocale]));
     }
 }


### PR DESCRIPTION
before PR 
when chaning `->soratable()` method with Translatable field 
the query was 
`select * from table_name order field asc;`

after PR
the query would be 
`select * from table_name order by json_unquote(json_extract(field, '$."ar"')) asc;`

<img width="431" alt="Screen Shot 2020-07-19 at 2 21 19 AM" src="https://user-images.githubusercontent.com/29691074/87864316-176c2800-c967-11ea-873d-617704585309.png">
<img width="359" alt="Screen Shot 2020-07-19 at 2 24 03 AM" src="https://user-images.githubusercontent.com/29691074/87864320-1b984580-c967-11ea-945e-7f167bbf3f0b.png">
